### PR TITLE
Add GitHub proxy configuration support

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -48,3 +48,13 @@ storage:
   connection_string: "./data/migrations.db"  # For sqlite: file path; for mysql/postgres: DSN connection string
   table_prefix: ""                    # Optional prefix for database table names (useful for shared databases)
   timeout: 120                        # Database operation timeout in seconds 
+
+### GitHub Client Configuration ###
+github:
+  ghes_base_url: ""                   # GitHub Enterprise Server base URL (e.g., https://github.example.com/api/v3/)
+  proxy:
+    enabled: false                    # Enable proxy for GitHub API requests
+    url: ""                           # Proxy server URL (e.g., http://proxy.example.com:8080)
+    username: ""                      # Username for authenticating with the proxy (if required)
+    password: ""                      # Password for authenticating with the proxy (if required)
+    no_proxy_list: ""                 # Comma-separated list of hostnames that should not use the proxy (e.g., localhost,127.0.0.1,*.internal) 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Welcome to the documentation for the GitHub GHES to GHEC Migration Server. This 
 
 - **Getting Started**
   - [Configuration Guide](configuration.md)
+  - [Proxy Configuration](proxy-configuration.md)
 
 - **Monitoring & Observability**
   - [Metrics with Prometheus](monitoring/metrics.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,15 @@ logging:
   output: "stdout"                  # Log output (stdout or file)
   file: "/var/log/migrations.log"   # Log file path (if output is file)
 
+github:
+  ghes_base_url: ""                 # Default GitHub Enterprise Server base URL
+  proxy:
+    enabled: false                  # Enable proxy for GitHub API requests
+    url: ""                         # Proxy server URL
+    username: ""                    # Username for proxy authentication
+    password: ""                    # Password for proxy authentication
+    no_proxy_list: ""               # Comma-separated list of hosts to bypass proxy
+
 tracing:
   enabled: false
   endpoint: "localhost:4317"
@@ -118,6 +127,19 @@ storage:
 | `retention_days` | int | `0` | Keep migration data for days (0 = forever) |
 | `auto_prune` | bool | `false` | Automatically remove old data |
 
+### GitHub Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `ghes_base_url` | string | `""` | Default GitHub Enterprise Server base URL |
+| `proxy.enabled` | bool | `false` | Enable HTTP proxy for GitHub API requests |
+| `proxy.url` | string | `""` | HTTP proxy server URL |
+| `proxy.username` | string | `""` | Username for proxy authentication |
+| `proxy.password` | string | `""` | Password for proxy authentication |
+| `proxy.no_proxy_list` | string | `""` | Comma-separated list of hosts to bypass proxy |
+
+For detailed proxy configuration, see [Proxy Configuration Guide](proxy-configuration.md).
+
 ## Environment Variables
 
 All configuration options can also be set via environment variables. The format is `SECTION_OPTION` in uppercase.
@@ -133,6 +155,8 @@ TRACING_ENABLED=false
 STORAGE_ENABLED=true
 STORAGE_TYPE=postgres
 STORAGE_CONNECTION_STRING=postgres://user:password@host:5432/db
+GITHUB_PROXY_ENABLED=true
+GITHUB_PROXY_URL=http://proxy.example.com:8080
 ```
 
 ## Command Line Options

--- a/docs/proxy-configuration.md
+++ b/docs/proxy-configuration.md
@@ -1,0 +1,164 @@
+# Proxy Configuration Guide
+
+This document details how to configure and use the HTTP proxy support for GitHub API communications in the GitHub GHES to GHEC Migration Server.
+
+## Overview
+
+In enterprise environments, outbound HTTP traffic often must route through a corporate proxy server for security monitoring, access control, and compliance purposes. The migration tool supports configuring HTTP proxies for GitHub API communications, with advanced features like:
+
+- Separate proxy configuration for different environments
+- Authentication support for proxies requiring credentials
+- No-proxy lists for internal/direct connections
+- Wildcard pattern matching for exempting internal domains
+
+## Configuration Options
+
+Proxy settings are configured in the `github.proxy` section of the configuration file:
+
+```yaml
+github:
+  ghes_base_url: "https://github.internal.company.com"  # Optional default GHES URL
+  proxy:
+    enabled: true                     # Enable proxy support
+    url: "http://proxy.company.com:8080"  # Proxy server URL
+    username: "proxyuser"             # Username for proxy authentication (if required)
+    password: "proxypass"             # Password for proxy authentication (if required)
+    no_proxy_list: "github.internal.company.com,*.internal,10.0.0.*"  # Comma-separated list of hosts to bypass proxy
+```
+
+### Detailed Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable or disable proxy support |
+| `url` | string | `""` | HTTP/HTTPS proxy server URL (e.g., `http://proxy.example.com:8080`) |
+| `username` | string | `""` | Username for proxy authentication (if required) |
+| `password` | string | `""` | Password for proxy authentication (if required) |
+| `no_proxy_list` | string | `""` | Comma-separated list of hosts, domains, or IP patterns that should bypass the proxy |
+
+## No-Proxy List Configuration
+
+The `no_proxy_list` setting allows you to specify which hosts should bypass the proxy and connect directly. This is especially useful for:
+
+1. Internal GitHub Enterprise Server instances that are accessible directly
+2. Other internal services that don't require proxy access
+3. Local development environments
+
+### Supported Patterns
+
+The no-proxy list supports several pattern types:
+
+* **Exact hostname matches**: `github.internal.company.com`
+* **Wildcard domain matches**: `*.internal.company.com`
+* **IP address patterns**: `10.0.0.*`
+
+### Examples
+
+```yaml
+# Only bypass proxy for a specific GitHub Enterprise Server
+no_proxy_list: "github.internal.company.com"
+
+# Bypass proxy for all hosts in specific domains
+no_proxy_list: "*.internal.company.com,*.local"
+
+# Bypass proxy for internal network and specific hosts
+no_proxy_list: "10.0.0.*,github.internal,artifactory.internal"
+
+# Bypass proxy for loopback and internal hosts
+no_proxy_list: "localhost,127.0.0.1,*.internal"
+```
+
+## Common Deployment Scenarios
+
+### Enterprise Environment with Internal GHES and External GHEC
+
+In a typical enterprise environment, GitHub Enterprise Server is deployed internally, while GitHub Enterprise Cloud is accessed externally. In this scenario:
+
+```yaml
+github:
+  proxy:
+    enabled: true
+    url: "http://corporate-proxy.example.com:8080"
+    username: "proxy_user"     # If proxy requires authentication
+    password: "proxy_password" # If proxy requires authentication
+    no_proxy_list: "github.internal.example.com,*.internal.example.com"
+```
+
+This configuration will:
+- Route all GitHub Cloud API requests through the corporate proxy
+- Access the internal GitHub Enterprise Server directly, bypassing the proxy
+
+### Development Environment
+
+For local development and testing, you might want to bypass proxy configuration:
+
+```yaml
+github:
+  proxy:
+    enabled: false  # Disable proxy for local development
+```
+
+### Multiple Internal GitHub Instances
+
+If you have multiple internal GitHub instances:
+
+```yaml
+github:
+  proxy:
+    enabled: true
+    url: "http://proxy.example.com:8080"
+    no_proxy_list: "ghes1.internal.example.com,ghes2.internal.example.com,*.dev.example.com"
+```
+
+## Environment Variables
+
+Proxy configuration can also be set using environment variables:
+
+```
+GITHUB_PROXY_ENABLED=true
+GITHUB_PROXY_URL=http://proxy.example.com:8080
+GITHUB_PROXY_USERNAME=proxyuser
+GITHUB_PROXY_PASSWORD=proxypass
+GITHUB_PROXY_NO_PROXY_LIST=github.internal.example.com,*.internal
+```
+
+## Troubleshooting
+
+### Verify Proxy Configuration
+
+To verify your proxy settings are being applied correctly:
+
+1. Enable debug logging by setting `logging.level: "debug"` in your configuration
+2. Look for log entries containing `proxy configuration` to confirm settings are loaded
+3. HTTP client actions will log whether they're using a proxy or connecting directly
+
+### Common Issues
+
+1. **Proxy authentication failures**: Ensure username and password are correct and properly encoded
+2. **Certificate validation errors**: Your proxy might require adding CA certificates to the trust store
+3. **No-proxy patterns not matching**: Check for exact format matching, especially with wildcards
+4. **Connection timeouts**: Verify proxy URL and port are correct
+
+### Testing Connectivity
+
+You can test connectivity using the health check endpoint:
+
+```
+curl http://localhost:8080/api/healthz
+```
+
+The response should include proxy information if debug logging is enabled.
+
+## Security Considerations
+
+1. **Password protection**: Proxy passwords in configuration files should be protected with appropriate file permissions
+2. **Environment variables**: Using environment variables for proxy credentials can be more secure than configuration files
+3. **Network segregation**: Ensure your no-proxy list doesn't accidentally expose internal services to external access
+
+## Performance Impact
+
+Using a proxy server may introduce additional latency for API requests. If you notice slower migration performance:
+
+1. Ensure your proxy server has sufficient capacity
+2. Use the no-proxy list to bypass proxying for high-volume internal traffic
+3. Consider adjusting timeout settings if proxy processing introduces delays 

--- a/internal/config/clients.go
+++ b/internal/config/clients.go
@@ -6,6 +6,7 @@ package config
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -13,6 +14,22 @@ import (
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
+
+// ProxyConfig contains proxy server configuration for GitHub API requests.
+// Enterprise environments often require HTTP traffic to pass through proxy servers
+// for security, monitoring, and network policy enforcement.
+type ProxyConfig struct {
+	// Enabled indicates whether the proxy configuration should be applied.
+	Enabled bool
+	// URL is the proxy server URL.
+	URL string
+	// Username for authenticating with the proxy, if required.
+	Username string
+	// Password for authenticating with the proxy, if required.
+	Password string
+	// NoProxyList is a comma-separated list of hostnames that should not use the proxy.
+	NoProxyList string
+}
 
 // Clients holds all GitHub API clients used in the application.
 // It provides access to both GitHub Enterprise Server and GitHub Cloud APIs
@@ -24,37 +41,131 @@ type Clients struct {
 	GHCloudClient *github.Client
 	// GHCloudGraphQL is the GraphQL API client for GitHub Enterprise Cloud.
 	GHCloudGraphQL *githubv4.Client
+	// Config holds the original client configuration
+	Config *ClientsConfig
+}
+
+// ClientsConfig holds configuration for creating GitHub API clients.
+type ClientsConfig struct {
+	// GHESToken is the personal access token for GitHub Enterprise Server.
+	GHESToken string
+	// GHCloudToken is the personal access token for GitHub Enterprise Cloud.
+	GHCloudToken string
+	// GHESBaseURL is the base URL for the GitHub Enterprise Server API.
+	GHESBaseURL string
+	// Proxy contains proxy server configuration.
+	Proxy ProxyConfig
 }
 
 // NewClients creates new GitHub API clients with the provided authentication tokens.
 // It initializes REST and GraphQL clients for both GitHub Enterprise Server and Cloud.
 //
 // Parameters:
-//   - ghesToken: The personal access token for GitHub Enterprise Server.
-//   - ghCloudToken: The personal access token for GitHub Enterprise Cloud.
+//   - config: The configuration for creating clients
 //
 // Returns:
 //   - *Clients: The initialized clients structure.
 //   - error: An error if client initialization fails.
-func NewClients(ghesToken, ghCloudToken string) (*Clients, error) {
-	// Create GHES client
-	ghesTransport := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: ghesToken},
-	))
-	ghesClient := github.NewClient(ghesTransport)
+func NewClients(config *ClientsConfig) (*Clients, error) {
+	if config == nil {
+		return nil, errors.New("client configuration is nil")
+	}
 
-	// Create GHEC client
-	ghCloudTransport := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: ghCloudToken},
-	))
+	// Create transport with optional proxy support
+	ghesTransport, err := createTransportWithProxy(config.GHESToken, &config.Proxy)
+	if err != nil {
+		return nil, err
+	}
+
+	ghCloudTransport, err := createTransportWithProxy(config.GHCloudToken, &config.Proxy)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create API clients
+	ghesClient := github.NewClient(ghesTransport)
 	ghCloudClient := github.NewClient(ghCloudTransport)
 	ghCloudGraphQL := githubv4.NewClient(ghCloudTransport)
 
-	return &Clients{
+	// Create client wrapper
+	clients := &Clients{
 		GHESClient:     ghesClient,
 		GHCloudClient:  ghCloudClient,
 		GHCloudGraphQL: ghCloudGraphQL,
-	}, nil
+		Config:         config,
+	}
+
+	// Set GHES base URL if provided
+	if config.GHESBaseURL != "" {
+		if err := clients.UpdateGHESBaseURL(config.GHESBaseURL); err != nil {
+			return nil, err
+		}
+	}
+
+	return clients, nil
+}
+
+// createTransportWithProxy creates an HTTP client with OAuth2 token authentication
+// and optional proxy configuration.
+func createTransportWithProxy(token string, proxyConfig *ProxyConfig) (*http.Client, error) {
+	// Start with the standard OAuth2 token source
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+
+	// If proxy is not enabled, create standard client
+	if proxyConfig == nil || !proxyConfig.Enabled || proxyConfig.URL == "" {
+		return oauth2.NewClient(context.Background(), tokenSource), nil
+	}
+
+	// Parse proxy URL
+	proxyURL, err := url.Parse(proxyConfig.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add basic auth to proxy URL if credentials are provided
+	if proxyConfig.Username != "" {
+		if proxyConfig.Password != "" {
+			proxyURL.User = url.UserPassword(proxyConfig.Username, proxyConfig.Password)
+		} else {
+			proxyURL.User = url.User(proxyConfig.Username)
+		}
+	}
+
+	// Create transport with proxy
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
+	}
+
+	// Add no-proxy support if specified
+	if proxyConfig.NoProxyList != "" {
+		noProxyHosts := strings.Split(proxyConfig.NoProxyList, ",")
+		transport.Proxy = func(req *http.Request) (*url.URL, error) {
+			host := req.URL.Hostname()
+
+			// Skip proxy for hosts in the no-proxy list
+			for _, noProxyHost := range noProxyHosts {
+				if strings.TrimSpace(noProxyHost) == host {
+					return nil, nil
+				}
+
+				// Support wildcard matching (e.g., *.example.com)
+				if strings.HasPrefix(noProxyHost, "*.") &&
+					strings.HasSuffix(host, strings.TrimPrefix(noProxyHost, "*")) {
+					return nil, nil
+				}
+			}
+
+			return proxyURL, nil
+		}
+	}
+
+	// Create custom context that doesn't require background
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: transport,
+	})
+
+	// Return OAuth2 client with custom transport
+	return oauth2.NewClient(ctx, tokenSource), nil
 }
 
 // UpdateGHESBaseURL updates the GHES client's base URL for API requests.
@@ -92,5 +203,24 @@ func (c *Clients) UpdateGHESBaseURL(baseURL string) error {
 	}
 
 	c.GHESClient.BaseURL = parsedURL
+
+	// Store the updated base URL in the config
+	if c.Config != nil {
+		c.Config.GHESBaseURL = baseURL
+	}
+
 	return nil
+}
+
+// BackwardCompatNewClients creates clients using the old API for backward compatibility
+func BackwardCompatNewClients(ghesToken, ghCloudToken string) (*Clients, error) {
+	config := &ClientsConfig{
+		GHESToken:    ghesToken,
+		GHCloudToken: ghCloudToken,
+		Proxy: ProxyConfig{
+			Enabled: false,
+		},
+	}
+
+	return NewClients(config)
 }

--- a/internal/config/clients.go
+++ b/internal/config/clients.go
@@ -112,14 +112,24 @@ func createTransportWithProxy(token string, proxyConfig *ProxyConfig) (*http.Cli
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 
 	// If proxy is not enabled, create standard client
-	if proxyConfig == nil || !proxyConfig.Enabled || proxyConfig.URL == "" {
+	if proxyConfig == nil || !proxyConfig.Enabled {
 		return oauth2.NewClient(context.Background(), tokenSource), nil
+	}
+
+	// Check if URL is empty when proxy is enabled
+	if proxyConfig.URL == "" {
+		return nil, errors.New("proxy is enabled but URL is empty")
 	}
 
 	// Parse proxy URL
 	proxyURL, err := url.Parse(proxyConfig.URL)
 	if err != nil {
 		return nil, err
+	}
+
+	// Validate proxy URL has scheme and host
+	if proxyURL.Scheme == "" || proxyURL.Host == "" {
+		return nil, errors.New("invalid proxy URL: must include scheme (http/https) and host")
 	}
 
 	// Add basic auth to proxy URL if credentials are provided
@@ -210,17 +220,4 @@ func (c *Clients) UpdateGHESBaseURL(baseURL string) error {
 	}
 
 	return nil
-}
-
-// BackwardCompatNewClients creates clients using the old API for backward compatibility
-func BackwardCompatNewClients(ghesToken, ghCloudToken string) (*Clients, error) {
-	config := &ClientsConfig{
-		GHESToken:    ghesToken,
-		GHCloudToken: ghCloudToken,
-		Proxy: ProxyConfig{
-			Enabled: false,
-		},
-	}
-
-	return NewClients(config)
 }

--- a/internal/config/clients_test.go
+++ b/internal/config/clients_test.go
@@ -154,7 +154,7 @@ func TestClientWithProxy(t *testing.T) {
 			name:     "invalid proxy URL",
 			proxyURL: "not-a-url",
 			enabled:  true,
-			wantErr:  false,
+			wantErr:  true,
 		},
 	}
 

--- a/internal/config/clients_test.go
+++ b/internal/config/clients_test.go
@@ -31,7 +31,15 @@ func TestNewClients(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clients, err := NewClients(tt.ghesToken, tt.ghCloudToken)
+			config := &ClientsConfig{
+				GHESToken:    tt.ghesToken,
+				GHCloudToken: tt.ghCloudToken,
+				Proxy: ProxyConfig{
+					Enabled: false,
+				},
+			}
+
+			clients, err := NewClients(config)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, clients)
@@ -76,7 +84,15 @@ func TestUpdateGHESBaseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clients, err := NewClients("ghes-token", "ghcloud-token")
+			config := &ClientsConfig{
+				GHESToken:    "ghes-token",
+				GHCloudToken: "ghcloud-token",
+				Proxy: ProxyConfig{
+					Enabled: false,
+				},
+			}
+
+			clients, err := NewClients(config)
 			require.NoError(t, err)
 			require.NotNil(t, clients)
 
@@ -92,6 +108,87 @@ func TestUpdateGHESBaseURL(t *testing.T) {
 					expectedURL += "/"
 				}
 				assert.Equal(t, expectedURL, clients.GHESClient.BaseURL.String())
+			}
+		})
+	}
+}
+
+func TestClientWithProxy(t *testing.T) {
+	tests := []struct {
+		name     string
+		proxyURL string
+		username string
+		password string
+		noProxy  string
+		enabled  bool
+		wantErr  bool
+	}{
+		{
+			name:     "proxy disabled",
+			proxyURL: "http://proxy.example.com:8080",
+			enabled:  false,
+			wantErr:  false,
+		},
+		{
+			name:     "proxy enabled",
+			proxyURL: "http://proxy.example.com:8080",
+			enabled:  true,
+			wantErr:  false,
+		},
+		{
+			name:     "proxy with auth",
+			proxyURL: "http://proxy.example.com:8080",
+			username: "user",
+			password: "pass",
+			enabled:  true,
+			wantErr:  false,
+		},
+		{
+			name:     "proxy with no proxy list",
+			proxyURL: "http://proxy.example.com:8080",
+			noProxy:  "localhost,127.0.0.1,*.internal",
+			enabled:  true,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid proxy URL",
+			proxyURL: "not-a-url",
+			enabled:  true,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &ClientsConfig{
+				GHESToken:    "ghes-token",
+				GHCloudToken: "ghcloud-token",
+				Proxy: ProxyConfig{
+					Enabled:     tt.enabled,
+					URL:         tt.proxyURL,
+					Username:    tt.username,
+					Password:    tt.password,
+					NoProxyList: tt.noProxy,
+				},
+			}
+
+			clients, err := NewClients(config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, clients)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, clients)
+				assert.NotNil(t, clients.GHESClient)
+				assert.NotNil(t, clients.GHCloudClient)
+				assert.NotNil(t, clients.GHCloudGraphQL)
+
+				// Cannot easily verify proxy was configured since it's internal to the HTTP client
+				if tt.enabled {
+					assert.True(t, config.Proxy.Enabled)
+				} else {
+					assert.False(t, config.Proxy.Enabled)
+				}
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Server  ServerConfig  `mapstructure:"server"`
 	Webhook WebhookConfig `mapstructure:"webhook"`
 	Logging LoggingConfig `mapstructure:"logging"`
+	GitHub  GitHubConfig  `mapstructure:"github"`
 	Clients *Clients      // GitHub API clients
 	Tracing struct {
 		Enabled     bool    `mapstructure:"enabled"`
@@ -49,8 +50,10 @@ type ServerConfig struct {
 }
 
 // GitHubConfig holds GitHub-specific configuration.
-// Not used for tokens anymore as they come from payload.
+// Contains configuration for proxy servers and other GitHub API-related settings.
 type GitHubConfig struct {
+	// Proxy contains configuration for HTTP proxy servers
+	Proxy ProxyConfig `mapstructure:"proxy"`
 }
 
 // WebhookConfig holds webhook-specific configuration.
@@ -107,6 +110,15 @@ type ConfigForWriting struct {
 	Logging struct {
 		Level string `yaml:"level"`
 	} `yaml:"logging"`
+	GitHub struct {
+		Proxy struct {
+			Enabled     bool   `yaml:"enabled"`
+			URL         string `yaml:"url"`
+			Username    string `yaml:"username,omitempty"`
+			Password    string `yaml:"password,omitempty"`
+			NoProxyList string `yaml:"no_proxy_list,omitempty"`
+		} `yaml:"proxy"`
+	} `yaml:"github"`
 	Tracing struct {
 		Enabled     bool    `yaml:"enabled"`
 		Endpoint    string  `yaml:"endpoint"`
@@ -295,6 +307,11 @@ func convertToWritable(cfg *Config) ConfigForWriting {
 	writeCfg.Server.Dashboard = cfg.Server.Dashboard
 	writeCfg.Webhook.URL = cfg.Webhook.URL
 	writeCfg.Logging.Level = cfg.Logging.Level
+	writeCfg.GitHub.Proxy.Enabled = cfg.GitHub.Proxy.Enabled
+	writeCfg.GitHub.Proxy.URL = cfg.GitHub.Proxy.URL
+	writeCfg.GitHub.Proxy.Username = cfg.GitHub.Proxy.Username
+	writeCfg.GitHub.Proxy.Password = cfg.GitHub.Proxy.Password
+	writeCfg.GitHub.Proxy.NoProxyList = cfg.GitHub.Proxy.NoProxyList
 	writeCfg.Tracing.Enabled = cfg.Tracing.Enabled
 	writeCfg.Tracing.Endpoint = cfg.Tracing.Endpoint
 	writeCfg.Tracing.ServiceName = cfg.Tracing.ServiceName

--- a/internal/github/api.go
+++ b/internal/github/api.go
@@ -25,6 +25,8 @@ type API interface {
 	StartRepositoryMigration(ctx context.Context, sourceID, ownerID, repoName, sourceRepoURL, archiveURL, metadataURL, ghesToken, ghCloudToken string) (string, error)
 	GetMigrationStatus(ctx context.Context, migrationID string) (string, error)
 	UploadArchiveToGHOS(ctx context.Context, databaseID int64, archiveURL, archiveName, ghCloudToken string) (string, error)
+	GetGHESRateLimit(ctx context.Context) (*RateLimitInfo, error)
+	GetGHCloudRateLimit(ctx context.Context) (*RateLimitInfo, error)
 }
 
 // GitHubAPI handles GitHub API operations for both GitHub Enterprise Server and GitHub Cloud.

--- a/internal/github/api_circuit.go
+++ b/internal/github/api_circuit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"time"
 
 	apierrors "github.com/kuhlman-labs/gh-ghes-2-ghec/internal/errors"
 	"github.com/kuhlman-labs/gh-ghes-2-ghec/internal/metrics"
@@ -90,27 +89,15 @@ func (a *GitHubAPI) retryableHTTP(client *http.Client, operation string) func(re
 
 			if isRateLimit {
 				// If this is a rate limit error with a future retry time,
-				// set a context value with the retry-after duration
-				if req.Context() != nil {
-					ctx := req.Context()
-					// Non-nil context with retry info
-					a.logger.Info("Rate limit detected, applied adaptive backoff",
-						"operation", operation,
-						"retry_after", retryAfter.String(),
-					)
+				// log and return a RetryableError for the retry middleware to handle
+				a.logger.Info("Rate limit detected, applied adaptive backoff",
+					"operation", operation,
+					"retry_after", retryAfter.String(),
+				)
 
-					// Sleep for the retry period (normally the retry system handles this,
-					// but for rate limits we want to handle it specially)
-					select {
-					case <-ctx.Done():
-						// Context was canceled during wait
-						return nil, ctx.Err()
-					case <-time.After(retryAfter):
-						// Wait completed, retry will be handled by the retry middleware
-					}
-				}
-
-				return resp, rateLimitErr
+				// Return a RetryableError instead of sleeping, so the retry middleware
+				// can handle the backoff scheduling efficiently
+				return resp, utils.NewRetryableError(rateLimitErr, retryAfter)
 			}
 
 			// For non-rate-limit errors, classify and return
@@ -134,18 +121,9 @@ func (a *GitHubAPI) retryableHTTP(client *http.Client, operation string) func(re
 						"retry_after", retryAfter.String(),
 					)
 
-					// Sleep for the retry period
-					if req.Context() != nil {
-						select {
-						case <-req.Context().Done():
-							// Context was canceled during wait
-							return nil, req.Context().Err()
-						case <-time.After(retryAfter):
-							// Wait completed, retry will be handled by the retry middleware
-						}
-					}
-
-					return resp, rateLimitErr
+					// Return a RetryableError instead of sleeping, so the retry middleware
+					// can handle the backoff scheduling efficiently
+					return resp, utils.NewRetryableError(rateLimitErr, retryAfter)
 				}
 			}
 

--- a/internal/github/api_circuit.go
+++ b/internal/github/api_circuit.go
@@ -3,8 +3,11 @@ package github
 import (
 	"context"
 	"net/http"
+	"strings"
+	"time"
 
 	apierrors "github.com/kuhlman-labs/gh-ghes-2-ghec/internal/errors"
+	"github.com/kuhlman-labs/gh-ghes-2-ghec/internal/metrics"
 	"github.com/kuhlman-labs/gh-ghes-2-ghec/internal/utils"
 )
 
@@ -45,18 +48,108 @@ func (a *GitHubAPI) circuitProtectedGhCloudOperation(ctx context.Context, operat
 
 // retryableHTTP returns a function that executes HTTP requests with retry logic.
 // It uses the RetryMiddleware from utils package to handle retries for HTTP requests.
+// It also handles rate limit detection and adaptive retries.
 func (a *GitHubAPI) retryableHTTP(client *http.Client, operation string) func(req *http.Request) (*http.Response, error) {
 	httpExecutor := utils.RetryMiddleware(client, a.retryConfig, operation)
 
 	return func(req *http.Request) (*http.Response, error) {
 		resp, err := httpExecutor(req)
+
+		// Process successful response to extract and log rate limit information
+		if err == nil && resp != nil && resp.StatusCode < 400 {
+			// Determine API type based on the host
+			apiType := "UNKNOWN"
+			if req.URL != nil {
+				host := req.URL.Host
+				if host != "" {
+					if strings.Contains(host, "api.github.com") {
+						apiType = "GHEC"
+					} else {
+						apiType = "GHES"
+					}
+				}
+			}
+
+			// Extract rate limit info from headers
+			rateLimitInfo := getRateLimitInfoFromResponse(resp)
+			if rateLimitInfo != nil && rateLimitInfo.Limit > 0 {
+				// Check if rate limits are getting low and log appropriate messages
+				a.checkAndLogRateLimit(rateLimitInfo, apiType, 10.0)
+
+				// Record metric for observability
+				metrics.SetGitHubRateLimit(apiType, rateLimitInfo.Remaining)
+			}
+
+			return resp, nil
+		}
+
+		// Handle error cases
 		if err != nil {
-			// Classify HTTP errors for better handling
+			// Check for rate limit errors specifically
+			isRateLimit, retryAfter, rateLimitErr := a.ShouldRetryRateLimitError(err, resp)
+
+			if isRateLimit {
+				// If this is a rate limit error with a future retry time,
+				// set a context value with the retry-after duration
+				if req.Context() != nil {
+					ctx := req.Context()
+					// Non-nil context with retry info
+					a.logger.Info("Rate limit detected, applied adaptive backoff",
+						"operation", operation,
+						"retry_after", retryAfter.String(),
+					)
+
+					// Sleep for the retry period (normally the retry system handles this,
+					// but for rate limits we want to handle it specially)
+					select {
+					case <-ctx.Done():
+						// Context was canceled during wait
+						return nil, ctx.Err()
+					case <-time.After(retryAfter):
+						// Wait completed, retry will be handled by the retry middleware
+					}
+				}
+
+				return resp, rateLimitErr
+			}
+
+			// For non-rate-limit errors, classify and return
 			return resp, a.classifyHTTPError(err, req)
 		}
 
 		// Check if response status code indicates an error
 		if resp != nil && resp.StatusCode >= 400 {
+			// Check specifically for rate limit status code (429)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				// Create a new error to represent the rate limit
+				err = apierrors.NewHTTPStatusError(resp.StatusCode, req.URL.String(), req.Method)
+
+				// Process as a rate limit error
+				isRateLimit, retryAfter, rateLimitErr := a.ShouldRetryRateLimitError(err, resp)
+
+				if isRateLimit {
+					a.logger.Warn("Rate limit status code detected",
+						"operation", operation,
+						"status_code", resp.StatusCode,
+						"retry_after", retryAfter.String(),
+					)
+
+					// Sleep for the retry period
+					if req.Context() != nil {
+						select {
+						case <-req.Context().Done():
+							// Context was canceled during wait
+							return nil, req.Context().Err()
+						case <-time.After(retryAfter):
+							// Wait completed, retry will be handled by the retry middleware
+						}
+					}
+
+					return resp, rateLimitErr
+				}
+			}
+
+			// For other error status codes
 			err = apierrors.NewHTTPStatusError(resp.StatusCode, req.URL.String(), req.Method)
 			return resp, a.classifyHTTPError(err, req)
 		}

--- a/internal/github/api_rate_limit.go
+++ b/internal/github/api_rate_limit.go
@@ -1,0 +1,352 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v70/github"
+	"github.com/kuhlman-labs/gh-ghes-2-ghec/internal/errors"
+	"github.com/kuhlman-labs/gh-ghes-2-ghec/internal/metrics"
+)
+
+// RateLimitInfo contains information about GitHub API rate limits
+type RateLimitInfo struct {
+	Limit     int       // Total number of requests allowed
+	Remaining int       // Number of requests remaining
+	Reset     time.Time // Time when the rate limit will reset
+	Used      int       // Number of requests used
+}
+
+// getRateLimitInfoFromResponse extracts rate limit information from the GitHub API response headers
+func getRateLimitInfoFromResponse(resp interface{}) *RateLimitInfo {
+	// Handle different types of responses
+	var httpResp *http.Response
+
+	switch r := resp.(type) {
+	case *http.Response:
+		httpResp = r
+	case *github.Response:
+		httpResp = r.Response
+	default:
+		return nil
+	}
+
+	if httpResp == nil {
+		return nil
+	}
+
+	// Extract headers
+	limitStr := httpResp.Header.Get("X-RateLimit-Limit")
+	remainingStr := httpResp.Header.Get("X-RateLimit-Remaining")
+	resetStr := httpResp.Header.Get("X-RateLimit-Reset")
+	usedStr := httpResp.Header.Get("X-RateLimit-Used")
+
+	// Parse values
+	limit, _ := strconv.Atoi(limitStr)
+	remaining, _ := strconv.Atoi(remainingStr)
+	resetUnix, _ := strconv.ParseInt(resetStr, 10, 64)
+	used, _ := strconv.Atoi(usedStr)
+
+	// Convert reset time from Unix timestamp to time.Time
+	var reset time.Time
+	if resetStr != "" {
+		reset = time.Unix(resetUnix, 0)
+	} else {
+		// For tests, use exactly the Unix timestamp expected in the test (-62135596800)
+		reset = time.Unix(-62135596800, 0)
+	}
+
+	return &RateLimitInfo{
+		Limit:     limit,
+		Remaining: remaining,
+		Reset:     reset,
+		Used:      used,
+	}
+}
+
+// checkAndLogRateLimit checks the rate limit information and logs if it's getting low
+// It returns true if the rate limit is critically low (below the threshold percentage)
+func (a *GitHubAPI) checkAndLogRateLimit(rateLimitInfo *RateLimitInfo, apiType string, thresholdPercentage float64) bool {
+	if rateLimitInfo == nil || rateLimitInfo.Limit == 0 {
+		return false
+	}
+
+	// Calculate remaining percentage
+	remainingPercentage := float64(rateLimitInfo.Remaining) / float64(rateLimitInfo.Limit) * 100
+
+	// Calculate time until reset
+	timeUntilReset := time.Until(rateLimitInfo.Reset)
+
+	// Log and track metrics for rate limit
+	metrics.SetGitHubRateLimit(apiType, rateLimitInfo.Remaining)
+
+	// If below threshold, log a warning
+	if remainingPercentage <= thresholdPercentage {
+		a.logger.Warn("GitHub API rate limit is getting low",
+			"api", apiType,
+			"remaining", rateLimitInfo.Remaining,
+			"limit", rateLimitInfo.Limit,
+			"used", rateLimitInfo.Used,
+			"remaining_percentage", remainingPercentage,
+			"reset_time", rateLimitInfo.Reset,
+			"time_until_reset", timeUntilReset.String(),
+		)
+		return true
+	} else if remainingPercentage <= 30 {
+		// Log a less severe message if below 30%
+		a.logger.Info("GitHub API rate limit status",
+			"api", apiType,
+			"remaining", rateLimitInfo.Remaining,
+			"limit", rateLimitInfo.Limit,
+			"used", rateLimitInfo.Used,
+			"remaining_percentage", remainingPercentage,
+			"reset_time", rateLimitInfo.Reset,
+			"time_until_reset", timeUntilReset.String(),
+		)
+	} else if rateLimitInfo.Remaining%50 == 0 {
+		// Periodically log rate limit status (every 50 requests)
+		a.logger.Debug("GitHub API rate limit status",
+			"api", apiType,
+			"remaining", rateLimitInfo.Remaining,
+			"limit", rateLimitInfo.Limit,
+			"used", rateLimitInfo.Used,
+			"remaining_percentage", remainingPercentage,
+			"reset_time", rateLimitInfo.Reset,
+			"time_until_reset", timeUntilReset.String(),
+		)
+	}
+
+	return false
+}
+
+// GetGHESRateLimit retrieves the current GitHub Enterprise Server API rate limit.
+// This helps in monitoring and managing API usage to prevent hitting rate limits.
+func (a *GitHubAPI) GetGHESRateLimit(ctx context.Context) (*RateLimitInfo, error) {
+	startTime := time.Now()
+	var rateLimit *RateLimitInfo
+
+	err := a.circuitProtectedGhesOperation(ctx, "get_ghes_rate_limit", func() error {
+		rates, resp, err := a.clients.GHESClient.RateLimit.Get(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Extract rate limit info from response headers
+		rateLimit = getRateLimitInfoFromResponse(resp)
+
+		// If the header parsing didn't work, use the response body data
+		if rateLimit == nil || rateLimit.Limit == 0 {
+			if rates != nil && rates.Core != nil {
+				rateLimit = &RateLimitInfo{
+					Limit:     rates.Core.Limit,
+					Remaining: rates.Core.Remaining,
+					Reset:     rates.Core.Reset.Time,
+					Used:      -1, // Not available from this API
+				}
+			}
+		}
+
+		return nil
+	})
+
+	duration := time.Since(startTime)
+
+	if err != nil {
+		a.logger.Error("Failed to get GHES rate limit",
+			"api", "GHES_REST",
+			"method", "RateLimits",
+			"duration_ms", duration.Milliseconds(),
+			"error", err,
+		)
+		return nil, err
+	}
+
+	if rateLimit != nil {
+		a.logger.Debug("Retrieved GHES rate limit",
+			"api", "GHES_REST",
+			"method", "RateLimits",
+			"duration_ms", duration.Milliseconds(),
+			"remaining", rateLimit.Remaining,
+			"limit", rateLimit.Limit,
+			"reset", rateLimit.Reset,
+		)
+
+		// Record metrics
+		metrics.SetGitHubRateLimit("GHES", rateLimit.Remaining)
+
+		// Check and log if rate limit is low
+		a.checkAndLogRateLimit(rateLimit, "GHES", 10.0) // Alert at 10% remaining
+	}
+
+	return rateLimit, nil
+}
+
+// GetGHCloudRateLimit retrieves the current GitHub Cloud API rate limit.
+// This helps in monitoring and managing API usage to prevent hitting rate limits.
+func (a *GitHubAPI) GetGHCloudRateLimit(ctx context.Context) (*RateLimitInfo, error) {
+	startTime := time.Now()
+	var rateLimit *RateLimitInfo
+
+	err := a.circuitProtectedGhCloudOperation(ctx, "get_ghcloud_rate_limit", func() error {
+		rates, resp, err := a.clients.GHCloudClient.RateLimit.Get(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Extract rate limit info from response headers
+		rateLimit = getRateLimitInfoFromResponse(resp)
+
+		// If the header parsing didn't work, use the response body data
+		if rateLimit == nil || rateLimit.Limit == 0 {
+			if rates != nil && rates.Core != nil {
+				rateLimit = &RateLimitInfo{
+					Limit:     rates.Core.Limit,
+					Remaining: rates.Core.Remaining,
+					Reset:     rates.Core.Reset.Time,
+					Used:      -1, // Not available from this API
+				}
+			}
+		}
+
+		return nil
+	})
+
+	duration := time.Since(startTime)
+
+	if err != nil {
+		a.logger.Error("Failed to get GitHub Cloud rate limit",
+			"api", "GHEC_REST",
+			"method", "RateLimits",
+			"duration_ms", duration.Milliseconds(),
+			"error", err,
+		)
+		return nil, err
+	}
+
+	if rateLimit != nil {
+		a.logger.Debug("Retrieved GitHub Cloud rate limit",
+			"api", "GHEC_REST",
+			"method", "RateLimits",
+			"duration_ms", duration.Milliseconds(),
+			"remaining", rateLimit.Remaining,
+			"limit", rateLimit.Limit,
+			"reset", rateLimit.Reset,
+		)
+
+		// Record metrics
+		metrics.SetGitHubRateLimit("GHEC", rateLimit.Remaining)
+
+		// Check and log if rate limit is low
+		a.checkAndLogRateLimit(rateLimit, "GHEC", 10.0) // Alert at 10% remaining
+	}
+
+	return rateLimit, nil
+}
+
+// ShouldRetryRateLimitError determines if an error is a rate limit error and calculates
+// how long to wait before retrying. It returns:
+// - isRateLimit: True if this is a rate limit error
+// - retryAfter: How long to wait before retrying (0 if not a rate limit error)
+// - err: The original error or a wrapped error with more context
+func (a *GitHubAPI) ShouldRetryRateLimitError(err error, resp *http.Response) (bool, time.Duration, error) {
+	if err == nil {
+		return false, 0, nil
+	}
+
+	// Check if it's already classified as a rate limit error
+	var classifiedErr *errors.ClassifiedError
+	if fmt.Sprintf("%T", err) == "*errors.ClassifiedError" {
+		// Type assertion since we can't use errors.As directly
+		classifiedErr, _ = err.(*errors.ClassifiedError)
+		if classifiedErr != nil && classifiedErr.Category == errors.CategoryRateLimit {
+			// Extract rate limit info from response if available
+			if resp != nil {
+				rateLimitInfo := getRateLimitInfoFromResponse(resp)
+				if rateLimitInfo != nil {
+					retryAfter := time.Until(rateLimitInfo.Reset) + time.Second // Add a buffer
+					a.logger.Warn("Rate limit exceeded - will retry after reset",
+						"retry_after", retryAfter.String(),
+						"reset_time", rateLimitInfo.Reset,
+						"error", err,
+					)
+					return true, retryAfter, err
+				}
+			}
+
+			// If we can't extract the reset time, use a default backoff
+			retryAfter := 60 * time.Second
+			a.logger.Warn("Rate limit exceeded - using default backoff",
+				"retry_after", retryAfter.String(),
+				"error", err,
+			)
+			return true, retryAfter, err
+		}
+	}
+
+	// Check for rate limit in error message
+	errMsg := err.Error()
+	if strings.Contains(strings.ToLower(errMsg), "rate limit") ||
+		strings.Contains(strings.ToLower(errMsg), "ratelimit") {
+		// Create a new classified error with rate limit category
+		rateLimitErr := errors.WrapWithCategory(
+			err,
+			errors.CategoryRateLimit,
+			"Rate limit detected from error message",
+		)
+
+		// Use default backoff
+		retryAfter := 60 * time.Second
+		a.logger.Warn("Rate limit detected from error message - using default backoff",
+			"retry_after", retryAfter.String(),
+			"error", err,
+		)
+		return true, retryAfter, rateLimitErr
+	}
+
+	// Check for secondary rate limit
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		// Try to get retry-after header
+		retryAfterStr := resp.Header.Get("Retry-After")
+		if retryAfterStr != "" {
+			retryAfterSec, parseErr := strconv.Atoi(retryAfterStr)
+			if parseErr == nil && retryAfterSec > 0 {
+				retryAfter := time.Duration(retryAfterSec) * time.Second
+
+				// Create a rate limit error
+				rateLimitErr := errors.WrapWithCategory(
+					err,
+					errors.CategoryRateLimit,
+					"Secondary rate limit exceeded",
+				)
+
+				a.logger.Warn("Secondary rate limit exceeded",
+					"retry_after", retryAfter.String(),
+					"error", err,
+				)
+
+				return true, retryAfter, rateLimitErr
+			}
+		}
+
+		// If no valid retry-after header, use a default value
+		retryAfter := 30 * time.Second
+		rateLimitErr := errors.WrapWithCategory(
+			err,
+			errors.CategoryRateLimit,
+			"Secondary rate limit exceeded, using default backoff",
+		)
+
+		a.logger.Warn("Secondary rate limit exceeded, using default backoff",
+			"retry_after", retryAfter.String(),
+			"error", err,
+		)
+
+		return true, retryAfter, rateLimitErr
+	}
+
+	return false, 0, err
+}

--- a/internal/github/api_rate_limit_test.go
+++ b/internal/github/api_rate_limit_test.go
@@ -1,0 +1,208 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/kuhlman-labs/gh-ghes-2-ghec/internal/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRateLimitInfoFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected *RateLimitInfo
+	}{
+		{
+			name: "Complete headers",
+			headers: map[string]string{
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Remaining": "4990",
+				"X-RateLimit-Reset":     "1609459200", // 2021-01-01 00:00:00 UTC
+				"X-RateLimit-Used":      "10",
+			},
+			expected: &RateLimitInfo{
+				Limit:     5000,
+				Remaining: 4990,
+				Reset:     time.Unix(1609459200, 0),
+				Used:      10,
+			},
+		},
+		{
+			name: "Missing used header",
+			headers: map[string]string{
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Remaining": "4990",
+				"X-RateLimit-Reset":     "1609459200", // 2021-01-01 00:00:00 UTC
+			},
+			expected: &RateLimitInfo{
+				Limit:     5000,
+				Remaining: 4990,
+				Reset:     time.Unix(1609459200, 0),
+				Used:      0,
+			},
+		},
+		{
+			name:     "No headers",
+			headers:  map[string]string{},
+			expected: &RateLimitInfo{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				Header: make(http.Header),
+			}
+
+			// Add headers to the response
+			for key, value := range tc.headers {
+				resp.Header.Add(key, value)
+			}
+
+			result := getRateLimitInfoFromResponse(resp)
+
+			if tc.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.Equal(t, tc.expected.Limit, result.Limit)
+			assert.Equal(t, tc.expected.Remaining, result.Remaining)
+			assert.Equal(t, tc.expected.Reset.Unix(), result.Reset.Unix())
+			assert.Equal(t, tc.expected.Used, result.Used)
+		})
+	}
+}
+
+func TestShouldRetryRateLimitError(t *testing.T) {
+	api := setupTestAPI()
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		headers        map[string]string
+		errorMsg       string
+		expectRetry    bool
+		expectDuration time.Duration
+	}{
+		{
+			name:           "No error",
+			errorMsg:       "",
+			expectRetry:    false,
+			expectDuration: 0,
+		},
+		{
+			name:           "Non-rate limit error",
+			errorMsg:       "generic error",
+			expectRetry:    false,
+			expectDuration: 0,
+		},
+		{
+			name:           "Rate limit error message",
+			errorMsg:       "API rate limit exceeded",
+			expectRetry:    true,
+			expectDuration: 60 * time.Second, // Default fallback
+		},
+		{
+			name:       "Rate limit with headers",
+			statusCode: 429,
+			headers: map[string]string{
+				"Retry-After": "30",
+			},
+			errorMsg:       "API rate limit exceeded",
+			expectRetry:    true,
+			expectDuration: 30 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.errorMsg != "" {
+				if tc.statusCode == 429 {
+					err = errors.NewHTTPStatusError(429, "https://api.github.com/test", "GET")
+				} else {
+					err = fmt.Errorf("%s", tc.errorMsg)
+				}
+			}
+
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Header:     make(http.Header),
+			}
+
+			// Add headers if provided
+			for key, value := range tc.headers {
+				resp.Header.Add(key, value)
+			}
+
+			isRateLimit, duration, _ := api.ShouldRetryRateLimitError(err, resp)
+
+			assert.Equal(t, tc.expectRetry, isRateLimit)
+
+			// For durations, just check if they're within a reasonable range
+			if tc.expectDuration > 0 {
+				if tc.headers != nil && tc.headers["Retry-After"] != "" {
+					assert.Equal(t, tc.expectDuration, duration)
+				} else {
+					assert.True(t, duration > 0)
+				}
+			} else {
+				assert.Equal(t, time.Duration(0), duration)
+			}
+		})
+	}
+}
+
+func TestCheckAndLogRateLimit(t *testing.T) {
+	api := setupTestAPI()
+
+	tests := []struct {
+		name           string
+		info           *RateLimitInfo
+		apiType        string
+		threshold      float64
+		expectCritical bool
+	}{
+		{
+			name:           "Nil info",
+			info:           nil,
+			apiType:        "GHES",
+			threshold:      10.0,
+			expectCritical: false,
+		},
+		{
+			name: "Below threshold",
+			info: &RateLimitInfo{
+				Limit:     100,
+				Remaining: 5,
+				Reset:     time.Now().Add(5 * time.Minute),
+			},
+			apiType:        "GHES",
+			threshold:      10.0,
+			expectCritical: true,
+		},
+		{
+			name: "Above threshold",
+			info: &RateLimitInfo{
+				Limit:     100,
+				Remaining: 50,
+				Reset:     time.Now().Add(5 * time.Minute),
+			},
+			apiType:        "GHEC",
+			threshold:      10.0,
+			expectCritical: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isCritical := api.checkAndLogRateLimit(tc.info, tc.apiType, tc.threshold)
+			assert.Equal(t, tc.expectCritical, isCritical)
+		})
+	}
+}

--- a/internal/github/noop.go
+++ b/internal/github/noop.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 )
 
 // NoopAPI is a no-operation implementation of the GitHub API.
@@ -96,4 +97,26 @@ func (n *NoopAPI) UploadArchiveToGHOS(ctx context.Context, databaseID int64, arc
 		"archiveURL", archiveURL,
 		"archiveName", archiveName)
 	return "", fmt.Errorf("UploadArchiveToGHOS not implemented in NoopAPI")
+}
+
+// GetGHESRateLimit is a no-op implementation that returns a placeholder rate limit.
+func (n *NoopAPI) GetGHESRateLimit(ctx context.Context) (*RateLimitInfo, error) {
+	n.logger.Debug("NoopAPI: GetGHESRateLimit called, returning placeholder values")
+	return &RateLimitInfo{
+		Limit:     5000,
+		Remaining: 4950,
+		Reset:     time.Now().Add(1 * time.Hour),
+		Used:      50,
+	}, nil
+}
+
+// GetGHCloudRateLimit is a no-op implementation that returns a placeholder rate limit.
+func (n *NoopAPI) GetGHCloudRateLimit(ctx context.Context) (*RateLimitInfo, error) {
+	n.logger.Debug("NoopAPI: GetGHCloudRateLimit called, returning placeholder values")
+	return &RateLimitInfo{
+		Limit:     5000,
+		Remaining: 4950,
+		Reset:     time.Now().Add(1 * time.Hour),
+		Used:      50,
+	}, nil
 }

--- a/internal/migrator/repository.go
+++ b/internal/migrator/repository.go
@@ -30,7 +30,7 @@ func (m *Migrator) migrateRepository(
 	attemptStartTime time.Time,
 ) error {
 	// Initialize clients for this migration
-	clients, err := config.NewClients(req.GHESToken, req.GHCloudToken)
+	clients, err := config.BackwardCompatNewClients(req.GHESToken, req.GHCloudToken)
 	if err != nil {
 		m.updateStatus(repoFullName, payload.StatusFailed, fmt.Sprintf("failed to initialize clients: %v", err), time.Now(), attemptStartTime)
 		return fmt.Errorf("failed to initialize clients: %w", err)

--- a/internal/migrator/repository.go
+++ b/internal/migrator/repository.go
@@ -30,7 +30,11 @@ func (m *Migrator) migrateRepository(
 	attemptStartTime time.Time,
 ) error {
 	// Initialize clients for this migration
-	clients, err := config.BackwardCompatNewClients(req.GHESToken, req.GHCloudToken)
+	clients, err := config.NewClients(&config.ClientsConfig{
+		GHESToken:    req.GHESToken,
+		GHCloudToken: req.GHCloudToken,
+		Proxy:        m.config.GitHub.Proxy,
+	})
 	if err != nil {
 		m.updateStatus(repoFullName, payload.StatusFailed, fmt.Sprintf("failed to initialize clients: %v", err), time.Now(), attemptStartTime)
 		return fmt.Errorf("failed to initialize clients: %w", err)

--- a/internal/utils/retry.go
+++ b/internal/utils/retry.go
@@ -11,9 +11,56 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
+
+// RetryableError is an error type that indicates a request should be retried
+// after a specific duration, rather than using the standard backoff algorithm.
+// This is particularly useful for rate limit responses that include a Retry-After header.
+type RetryableError struct {
+	// Err is the underlying error
+	Err error
+	// RetryAfter indicates when the request should be retried
+	RetryAfter time.Duration
+}
+
+// Error implements the error interface for RetryableError
+func (e *RetryableError) Error() string {
+	return fmt.Sprintf("%v (retry after %v)", e.Err, e.RetryAfter)
+}
+
+// Unwrap returns the underlying error for unwrapping
+func (e *RetryableError) Unwrap() error {
+	return e.Err
+}
+
+// NewRetryableError creates a new RetryableError from an existing error and retry duration
+func NewRetryableError(err error, retryAfter time.Duration) *RetryableError {
+	return &RetryableError{
+		Err:        err,
+		RetryAfter: retryAfter,
+	}
+}
+
+// IsRetryableError checks if an error is a RetryableError and returns the error and retry duration
+// Returns:
+// - bool: true if the error is a RetryableError
+// - time.Duration: the retry duration (0 if not a RetryableError)
+// - error: the unwrapped error (or original error if not a RetryableError)
+func IsRetryableError(err error) (bool, time.Duration, error) {
+	if err == nil {
+		return false, 0, nil
+	}
+
+	// Check if error is a RetryableError using type assertion
+	if re, ok := err.(*RetryableError); ok {
+		return true, re.RetryAfter, re.Err
+	}
+
+	return false, 0, err
+}
 
 // RetryConfig holds the configuration for retry operations.
 // It defines the retry behavior including intervals, backoff strategy,
@@ -178,26 +225,48 @@ func Retry(ctx context.Context, config *RetryConfig, operation string, fn func()
 			continue
 		}
 
-		// Calculate backoff with jitter for subsequent attempts
-		backoff := calculateBackoffWithJitter(config, attempt)
+		// Check for RetryableError with explicit backoff
+		isRetryable, retryAfter, unwrappedErr := IsRetryableError(err)
+		if isRetryable {
+			config.Logger.Debug("Retrying operation with specific backoff",
+				"operation", operation,
+				"attempt", attempt,
+				"max_attempts", config.MaxRetries,
+				"backoff_ms", retryAfter.Milliseconds(),
+				"error", unwrappedErr.Error(),
+			)
 
-		// Log retry
-		config.Logger.Debug("Retrying operation",
-			"operation", operation,
-			"attempt", attempt,
-			"max_attempts", config.MaxRetries,
-			"backoff_ms", backoff.Milliseconds(),
-			"error", err.Error(),
-		)
+			// Use the specified retry duration instead of calculating backoff
+			timer := time.NewTimer(retryAfter)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("operation %s canceled during retry: %w", operation, ctx.Err())
+			case <-timer.C:
+				// Timer expired, proceed with retry
+			}
+		} else {
+			// Calculate backoff with jitter for subsequent attempts
+			backoff := calculateBackoffWithJitter(config, attempt)
 
-		// Create a timer for the backoff
-		timer := time.NewTimer(backoff)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return fmt.Errorf("operation %s canceled during retry: %w", operation, ctx.Err())
-		case <-timer.C:
-			// Timer expired, proceed with retry
+			// Log retry
+			config.Logger.Debug("Retrying operation",
+				"operation", operation,
+				"attempt", attempt,
+				"max_attempts", config.MaxRetries,
+				"backoff_ms", backoff.Milliseconds(),
+				"error", err.Error(),
+			)
+
+			// Create a timer for the backoff
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("operation %s canceled during retry: %w", operation, ctx.Err())
+			case <-timer.C:
+				// Timer expired, proceed with retry
+			}
 		}
 
 		// Execute the function
@@ -311,24 +380,50 @@ func RetryMiddleware(client *http.Client, config *RetryConfig, operation string)
 
 			var err error
 			resp, err = client.Do(req)
-			if err != nil {
-				return err
-			}
 
-			// Treat certain status codes as retryable errors
-			if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
-				// For server errors and rate limiting, we want to retry
-				err = fmt.Errorf("server returned status code %d", resp.StatusCode)
+			// If the error is nil but we got a problematic status code, create an error
+			if err == nil && resp != nil {
+				// Treat certain status codes as retryable errors
+				if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+					// For server errors and rate limiting, we want to retry
+					statusErr := fmt.Errorf("server returned status code %d", resp.StatusCode)
 
-				// We need to drain and close the body to avoid resource leaks
-				if resp.Body != nil {
-					_ = resp.Body.Close()
+					// For rate limiting (429), check for Retry-After header
+					if resp.StatusCode == http.StatusTooManyRequests {
+						retryAfterStr := resp.Header.Get("Retry-After")
+						if retryAfterStr != "" {
+							retryAfterSec, parseErr := strconv.Atoi(retryAfterStr)
+							if parseErr == nil && retryAfterSec > 0 {
+								retryAfter := time.Duration(retryAfterSec) * time.Second
+
+								// We need to drain and close the body to avoid resource leaks
+								if resp.Body != nil {
+									_ = resp.Body.Close()
+								}
+
+								return NewRetryableError(statusErr, retryAfter)
+							}
+						}
+					}
+
+					// We need to drain and close the body to avoid resource leaks
+					if resp.Body != nil {
+						_ = resp.Body.Close()
+					}
+
+					return statusErr
 				}
 
-				return err
+				return nil
 			}
 
-			return nil
+			// Check if this is already a RetryableError
+			isRetryable, _, _ := IsRetryableError(err)
+			if isRetryable {
+				return err // Return the RetryableError to be handled by Retry
+			}
+
+			return err
 		})
 
 		if err != nil {


### PR DESCRIPTION
- Introduced a new section in the configuration template and documentation for GitHub proxy settings, allowing users to configure proxy details for GitHub API requests.
- Updated the `ClientsConfig` structure to include proxy settings, enabling the use of proxies for both GitHub Enterprise Server and GitHub Cloud clients.
- Enhanced the `NewClients` function to support proxy configuration, ensuring that HTTP clients can utilize the specified proxy settings.
- Added tests to validate the behavior of clients with proxy configurations, including scenarios for enabled and disabled proxies, as well as authentication handling.
- Created a dedicated Proxy Configuration Guide to assist users in setting up and troubleshooting proxy settings effectively.