### PR TITLE
Enhance Webhook Notification Handling to Avoid Race Conditions

### DIFF
--- a/internal/migrator/webhook.go
+++ b/internal/migrator/webhook.go
@@ -18,12 +18,29 @@ import (
 
 func (m *Migrator) sendWebhookNotification(repoName string, migrationReq *payload.MigrationRequest) {
 	m.mu.RLock()
-	status := m.migrations[repoName]
-	m.mu.RUnlock()
-
-	if status == nil {
+	originalStatus := m.migrations[repoName]
+	if originalStatus == nil {
+		m.mu.RUnlock()
 		return
 	}
+
+	// Make a copy of the status to avoid race conditions
+	status := &payload.MigrationStatus{
+		Repository:      originalStatus.Repository,
+		Status:          originalStatus.Status,
+		Stage:           originalStatus.Stage,
+		State:           originalStatus.State,
+		Progress:        originalStatus.Progress,
+		StageProgress:   originalStatus.StageProgress,
+		Error:           originalStatus.Error,
+		StartedAt:       originalStatus.StartedAt,
+		UpdatedAt:       originalStatus.UpdatedAt,
+		Duration:        originalStatus.Duration,
+		MigrationID:     originalStatus.MigrationID,
+		CompletedStages: make([]string, len(originalStatus.CompletedStages)),
+	}
+	copy(status.CompletedStages, originalStatus.CompletedStages)
+	m.mu.RUnlock()
 
 	// Skip if no webhook URL is configured
 	if m.webhookURL == "" {

--- a/internal/migrator/webhook.go
+++ b/internal/migrator/webhook.go
@@ -25,20 +25,8 @@ func (m *Migrator) sendWebhookNotification(repoName string, migrationReq *payloa
 	}
 
 	// Make a copy of the status to avoid race conditions
-	status := &payload.MigrationStatus{
-		Repository:      originalStatus.Repository,
-		Status:          originalStatus.Status,
-		Stage:           originalStatus.Stage,
-		State:           originalStatus.State,
-		Progress:        originalStatus.Progress,
-		StageProgress:   originalStatus.StageProgress,
-		Error:           originalStatus.Error,
-		StartedAt:       originalStatus.StartedAt,
-		UpdatedAt:       originalStatus.UpdatedAt,
-		Duration:        originalStatus.Duration,
-		MigrationID:     originalStatus.MigrationID,
-		CompletedStages: make([]string, len(originalStatus.CompletedStages)),
-	}
+	status := *originalStatus
+	status.CompletedStages = make([]string, len(originalStatus.CompletedStages))
 	copy(status.CompletedStages, originalStatus.CompletedStages)
 	m.mu.RUnlock()
 

--- a/internal/migrator/webhook_test.go
+++ b/internal/migrator/webhook_test.go
@@ -334,8 +334,11 @@ func TestSendWebhookNotificationConcurrent(t *testing.T) {
 	numWebhooks := 10
 	done := make(chan bool, numWebhooks)
 
+	// Populate all migration statuses first to avoid race conditions
+	repoNames := make([]string, numWebhooks)
 	for i := 0; i < numWebhooks; i++ {
 		repoName := fmt.Sprintf("test-org/test-repo-%d", i)
+		repoNames[i] = repoName
 		status := &payload.MigrationStatus{
 			Status:    payload.StatusInProgress,
 			Stage:     "archive",
@@ -343,7 +346,10 @@ func TestSendWebhookNotificationConcurrent(t *testing.T) {
 			UpdatedAt: time.Now(),
 		}
 		m.migrations[repoName] = status
+	}
 
+	// Now start all goroutines
+	for _, repoName := range repoNames {
 		go func(repo string) {
 			m.sendWebhookNotification(repo, nil)
 			done <- true

--- a/internal/migrator/webhook_test.go
+++ b/internal/migrator/webhook_test.go
@@ -332,7 +332,7 @@ func TestSendWebhookNotificationConcurrent(t *testing.T) {
 
 	// Send multiple concurrent webhook notifications
 	numWebhooks := 10
-	done := make(chan bool, numWebhooks)
+	var wg sync.WaitGroup
 
 	// Populate all migration statuses first to avoid race conditions
 	repoNames := make([]string, numWebhooks)
@@ -350,16 +350,15 @@ func TestSendWebhookNotificationConcurrent(t *testing.T) {
 
 	// Now start all goroutines
 	for _, repoName := range repoNames {
+		wg.Add(1)
 		go func(repo string) {
+			defer wg.Done()
 			m.sendWebhookNotification(repo, nil)
-			done <- true
 		}(repoName)
 	}
 
 	// Wait for all webhooks to complete
-	for i := 0; i < numWebhooks; i++ {
-		<-done
-	}
+	wg.Wait()
 
 	// Verify all requests were received
 	mu.Lock()


### PR DESCRIPTION
- Updated the TestSendWebhookNotificationConcurrent test to populate migration statuses before starting goroutines, preventing race conditions.
- Modified the sendWebhookNotification method to create a copy of the migration status, ensuring thread safety when accessing shared data.